### PR TITLE
Update search assistant drawable

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/SearchPanelView.java
+++ b/packages/SystemUI/src/com/android/systemui/SearchPanelView.java
@@ -98,6 +98,8 @@ public class SearchPanelView extends FrameLayout implements StatusBarPanel,
     private ImageView mLogoRight, mLogoLeft;
     private ShortcutPickHelper mPicker;
 
+    private ComponentName mCurrentAssistComponent = null;
+
     public SearchPanelView(Context context, AttributeSet attrs) {
         this(context, attrs, 0);
     }
@@ -172,8 +174,8 @@ public class SearchPanelView extends FrameLayout implements StatusBarPanel,
         Intent intent = ((SearchManager) mContext.getSystemService(Context.SEARCH_SERVICE))
                 .getAssistIntent(mContext, false, UserHandle.USER_CURRENT);
         if (intent != null) {
-            ComponentName component = intent.getComponent();
-            replaceDrawable(view, component, ASSIST_ICON_METADATA_NAME);
+            mCurrentAssistComponent = intent.getComponent();
+            replaceDrawable(view, mCurrentAssistComponent, ASSIST_ICON_METADATA_NAME);
         } else {
             mLogo.setImageDrawable(null);
         }
@@ -223,6 +225,7 @@ public class SearchPanelView extends FrameLayout implements StatusBarPanel,
 
     public void show(final boolean show, boolean animate) {
         if (show) {
+            maybeUpdateSearchDrawables();
             if (getVisibility() != View.VISIBLE) {
                 setVisibility(View.VISIBLE);
                 vibrate();
@@ -460,6 +463,29 @@ public class SearchPanelView extends FrameLayout implements StatusBarPanel,
                         mContext, mTargetActivities[i]));
         }
         updateTargetVisibility();
+    }
+
+    private void maybeUpdateSearchDrawables() {
+        // Nothing to do if no assistants are available
+        if (!isAssistantAvailable()) return;
+
+        Intent intent = ((SearchManager) mContext.getSystemService(Context.SEARCH_SERVICE))
+                .getAssistIntent(mContext, false, UserHandle.USER_CURRENT);
+        final ComponentName component = intent != null ? intent.getComponent() : null;
+        if (component != null && !component.equals(mCurrentAssistComponent)) {
+            mCurrentAssistComponent = component;
+            mTargetActivities = NavigationRingHelpers.getTargetActions(mContext);
+            for (int i = 0; i < NavigationRingHelpers.MAX_ACTIONS; i++) {
+                ImageView target = mTargetViews.get(i);
+                String action = mTargetActivities[i];
+
+                if (isAssistantAvailable() && ((TextUtils.isEmpty(action) && target == mLogo)
+                        || ACTION_ASSIST.equals(action))) {
+                    replaceDrawable(target, component, ASSIST_ICON_METADATA_NAME);
+                    continue;
+                }
+            }
+        }
     }
 
     private void updateTargetVisibility() {


### PR DESCRIPTION
If the user installs a 3rd party search assistant and chooses that
as the default action for the search assistant target, the drawable
should be updated.  This patch tracks the current search assistant
component and when the SearchPanelView is shown, the drawable is
updated if the default search assistant component has changed

Change-Id: I7c1770b66a0265c61b433759915db3f3094bd41b