### PR TITLE
base: API to expose mNavigationBarCanMove from window manager [1/3]

### DIFF
--- a/core/java/android/view/IWindowManager.aidl
+++ b/core/java/android/view/IWindowManager.aidl
@@ -258,6 +258,11 @@ interface IWindowManager
     boolean needsNavigationBar();
 
     /**
+     * Navigation bar window is currently capable of being vertical
+     */
+    boolean navigationBarCanMove();
+
+    /**
      * Lock the device immediately with the specified options (can be null).
      */
     void lockNow(in Bundle options);

--- a/core/java/android/view/WindowManagerPolicy.java
+++ b/core/java/android/view/WindowManagerPolicy.java
@@ -1259,6 +1259,11 @@ public interface WindowManagerPolicy {
     public boolean needsNavigationBar();
 
     /**
+     * Navigation bar window is currently capable of being vertical
+     */
+    public boolean navigationBarCanMove();
+
+    /**
      * Lock the device now.
      */
     public void lockNow(Bundle options);

--- a/services/core/java/com/android/server/policy/PhoneWindowManager.java
+++ b/services/core/java/com/android/server/policy/PhoneWindowManager.java
@@ -7459,6 +7459,11 @@ public class PhoneWindowManager implements WindowManagerPolicy {
     }
 
     @Override
+    public boolean navigationBarCanMove() {
+        return mNavigationBarCanMove;
+    }
+    
+    @Override
     public void setLastInputMethodWindowLw(WindowState ime, WindowState target) {
         mLastInputMethodWindow = ime;
         mLastInputMethodTargetWindow = target;

--- a/services/core/java/com/android/server/wm/WindowManagerService.java
+++ b/services/core/java/com/android/server/wm/WindowManagerService.java
@@ -11159,6 +11159,11 @@ public class WindowManagerService extends IWindowManager.Stub
     }
 
     @Override
+    public boolean navigationBarCanMove() {
+        return mPolicy.navigationBarCanMove();
+    }
+
+    @Override
     public void lockNow(Bundle options) {
         mPolicy.lockNow(options);
     }


### PR DESCRIPTION
We need to ensure the views that NavigationController inflate
are actually in line with the window behavior. It appears that
when custom dpi is set, window manager gets it right, but
NavigationController doesn't.

Change-Id: Idf4472ae3ff8de372c44cb7a370f21d125248ec6