### PR TITLE
Lockscreen: Fix off-center date view when there is no alarm

### DIFF
--- a/packages/Keyguard/src/com/android/keyguard/KeyguardStatusView.java
+++ b/packages/Keyguard/src/com/android/keyguard/KeyguardStatusView.java
@@ -340,27 +340,14 @@ public class KeyguardStatusView extends GridLayout implements
             mWeatherCurrentTemp.setTextColor(secondaryTextColor);
         }
 
-        if (showClock) {
-            mClockView = (TextClock) findViewById(R.id.clock_view);
-            mClockView.setVisibility(View.VISIBLE);
-        } else {
-            mClockView = (TextClock) findViewById(R.id.clock_view);
-            mClockView.setVisibility(View.INVISIBLE);
-        }
-        if (showDate) {
-            mDateView = (TextClock) findViewById(R.id.date_view);
-            mDateView.setVisibility(View.VISIBLE);
-        } else {
-            mDateView = (TextClock) findViewById(R.id.date_view);
-            mDateView.setVisibility(View.INVISIBLE);
-        }
-        if (showAlarm && nextAlarm != null) {
-            mAlarmStatusView = (TextView) findViewById(R.id.alarm_status);
-            mAlarmStatusView.setVisibility(View.VISIBLE);
-        } else {
-            mAlarmStatusView = (TextView) findViewById(R.id.alarm_status);
-            mAlarmStatusView.setVisibility(View.INVISIBLE);
-        }
+        mClockView = (TextClock) findViewById(R.id.clock_view);
+        mClockView.setVisibility(showClock ? View.VISIBLE : View.INVISIBLE);
+
+        mDateView = (TextClock) findViewById(R.id.date_view);
+        mDateView.setVisibility(showDate ? View.VISIBLE : View.INVISIBLE);
+
+        mAlarmStatusView = (TextView) findViewById(R.id.alarm_status);
+        mAlarmStatusView.setVisibility(showAlarm && nextAlarm != null ? View.VISIBLE : View.GONE);
 
         if (lockClockFont == 0) {
             mClockView.setTypeface(Typeface.create("sans-serif", Typeface.NORMAL));


### PR DESCRIPTION
Regression was caused by https://github.com/DirtyUnicorns/android_frameworks_base/commit/1a2a3d2411d148eb6ddb4b6aec3a9babe26b2792
If there are no pending alarms, the alarm view should be gone, not
invisible. Clean up some spaghetti while in the neighborhood.

Change-Id: Ieb4f171b7941223943ee518b0fc561c185afe0d4