### PR TITLE
fwb: services: tests: Remove duplicated WrappedAvoidBadWifiTracker class

### DIFF
--- a/services/tests/servicestests/src/com/android/server/ConnectivityServiceTest.java
+++ b/services/tests/servicestests/src/com/android/server/ConnectivityServiceTest.java
@@ -614,19 +614,6 @@ public class ConnectivityServiceTest extends AndroidTestCase {
         }
     }
 
-    private class WrappedAvoidBadWifiTracker extends AvoidBadWifiTracker {
-        public boolean configRestrictsAvoidBadWifi;
-
-        public WrappedAvoidBadWifiTracker(Context c, Handler h, Runnable r) {
-            super(c, h, r);
-        }
-
-        @Override
-        public boolean configRestrictsAvoidBadWifi() {
-            return configRestrictsAvoidBadWifi;
-        }
-    }
-
     private class WrappedConnectivityService extends ConnectivityService {
         public WrappedAvoidBadWifiTracker wrappedAvoidBadWifiTracker;
         private WrappedNetworkMonitor mLastCreatedNetworkMonitor;


### PR DESCRIPTION
 * ERROR: /frameworks/base/services/tests/servicestests/src/
          com/android/server/ConnectivityServiceTest.java:617:
          Duplicate nested type WrappedAvoidBadWifiTracker
    
   This was the result of a bad 7.1.1_r1 merge in commit
   c19f0656f0ae13d74c73f838ec1765d90f686fed.

Change-Id: Id5bb5f79a53f05a0d0c4932f739646ac6021e655